### PR TITLE
Move script injection before environment is loaded

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -642,12 +642,7 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
       adapter.unreliableTransport = sendViaPhoenix(false);
     });
     const loadEnvironmentAndConnect = async () => {
-      updateEnvironmentForHub(hub, entryManager);
-      function onConnectionError() {
-        console.error("Unknown error occurred while attempting to connect to networked scene.");
-        remountUI({ roomUnavailableReason: "connect_error" });
-        entryManager.exitScene();
-      }
+      // START custom scripts injection
 
       // Dynamically download scripts in parallel, but execute in sequence
       const scriptsArr = hub.user_data?.scripts ?? [];
@@ -657,6 +652,15 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
         await import(/* webpackIgnore: true */ URL.createObjectURL(blob));
       } catch (err) {
         console.error(`Custom scripts for this room failed to load. Reason: ${err}`);
+      }
+
+      // END custom scripts injection
+
+      updateEnvironmentForHub(hub, entryManager);
+      function onConnectionError() {
+        console.error("Unknown error occurred while attempting to connect to networked scene.");
+        remountUI({ roomUnavailableReason: "connect_error" });
+        entryManager.exitScene();
       }
 
       const connectionErrorTimeout = setTimeout(onConnectionError, 90000);

--- a/src/hub.js
+++ b/src/hub.js
@@ -1644,8 +1644,13 @@ Like ES6 dynamic import() but for multiple modules.
 Modules are downloaded in parallel and executed in sequence
 */
 function importAll(urls) {
-  const moduleStr = urls.map(url => `import '${url}';`).join("\n");
-  const blob = new Blob([moduleStr], { type: "application/javascript" });
-  const promise = import(/* webpackIgnore: true */ URL.createObjectURL(blob));
-  return promise;
+  if (urls?.length > 0) {
+    const moduleStr = urls.map(url => `import '${url}';`).join("\n");
+    const blob = new Blob([moduleStr], { type: "application/javascript" });
+    const promise = import(/* webpackIgnore: true */ URL.createObjectURL(blob));
+    return promise;
+  } else {
+    // If no urls were received, don't bother making a Blob
+    return Promise.resolve();
+  }
 }

--- a/src/hub.js
+++ b/src/hub.js
@@ -1508,9 +1508,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       await presenceSync.promise;
 
       try {
-        // If scriptsPromise is null (i.e. we rejoined) then this is a no-op
         await scriptsPromise;
       } catch (err) {
+        // Error may arise if URL to a script is broken, we don't want to block scene loading
         console.error(`Custom scripts for this room failed to load. Reason: ${err}`);
       }
 


### PR DESCRIPTION
This resolves a timing issue where components encoded in the Hubs glTF
extension were parsed and discarded before custom scripts could run.